### PR TITLE
Extended SpringTemplateLoader with better resource loader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<version>0.2.0</version>
 	<name>Spring interface to the Jade compiler</name>
 	<properties>
-		<org.springframework.version>3.0.5.RELEASE</org.springframework.version>
+		<org.springframework.version>3.0.7.RELEASE</org.springframework.version>
 		<servlet-api-version>2.5</servlet-api-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>de.neuland</groupId>
 			<artifactId>jade4j</artifactId>
-			<version>0.2.3</version>
+			<version>0.2.6</version>
 		</dependency>
 
 		<!-- Spring framework -->

--- a/src/main/java/de/neuland/jade4j/spring/template/SpringTemplateLoader.java
+++ b/src/main/java/de/neuland/jade4j/spring/template/SpringTemplateLoader.java
@@ -4,25 +4,40 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 
-import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 
 import de.neuland.jade4j.template.TemplateLoader;
+import javax.annotation.PostConstruct;
+import javax.servlet.ServletContext;
+import org.springframework.web.context.ServletContextAware;
+import org.springframework.web.context.support.ServletContextResourceLoader;
 
-public class SpringTemplateLoader implements TemplateLoader {
+public class SpringTemplateLoader implements TemplateLoader, ServletContextAware {
 
-	private final ResourceLoader resourceLoader;
+        private ResourceLoader resourceLoader;
+        private String encoding = "UTF-8";
+        private String suffix = ".jade";
+        private String basePath = "";
+        private ServletContext context;
 
-	private String encoding = "UTF-8";
-	private String suffix = ".jade";
-	private String basePath = "";
+        @PostConstruct
+        public void init() {
+            if(this.resourceLoader == null) {
+                this.resourceLoader = new ServletContextResourceLoader(context);
+            }
+        }
 
-	public SpringTemplateLoader() {
-		this.resourceLoader = new DefaultResourceLoader();
-	}
+        @Override
+        public void setServletContext(ServletContext servletContext) {
+            this.context = servletContext;
+        }
 
-	@Override
+        public void setResourceLoader(ResourceLoader resourceLoader) {
+            this.resourceLoader = resourceLoader;
+        }
+        
+        @Override
 	public long getLastModified(String name) {
 		Resource resource = getResource(name);
 		try {


### PR DESCRIPTION
Using the DefaultResourceLoader requires the jade files to be available at classpath which is not always the case during development. 

I have:
- added a setter for the resource loader
- bumped the spring dependency to 3.0.7 (was 3.0.5)
- changed the default to a ServletContextResourceLoader instance

The ServletContextResourceLoader retrieves the resource through the servletcontext instead. This makes it possible to edit Jade files and see the result without restarting the webserver in many IDE's.
