### PR TITLE
Add Spring JavaConfig example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,37 @@ applicationContext.xml
 	<property name="renderExceptions" value="true" />
 </bean>
 ```
+Or, if you are using Spring JavaConfig:
 
+```java
+@Configuration
+public class JadeConfig {
+
+	@Bean
+	public SpringTemplateLoader templateLoader() {
+		SpringTemplateLoader templateLoader = new SpringTemplateLoader();
+		templateLoader.setBasePath("/WEB-INF/views/");
+		templateLoader.setEncoding("UTF-8");
+		templateLoader.setSuffix(".jade");
+		return templateLoader;
+	}
+
+	@Bean
+	public JadeConfiguration jadeConfiguration() {
+		JadeConfiguration configuration = new JadeConfiguration();
+		configuration.setCaching(false);
+		configuration.setTemplateLoader(templateLoader());
+		return configuration;
+	}
+
+	@Bean
+	public ViewResolver viewResolver() {
+		JadeViewResolver viewResolver = new JadeViewResolver();
+		viewResolver.setConfiguration(jadeConfiguration());
+		return viewResolver;
+	}
+}
+```
 
 ## Usage
 


### PR DESCRIPTION
This patch adds a Spring JavaConfig example to the README.
