### PR TITLE
Unpack any BindingResults in the model to a usable form

### DIFF
--- a/src/main/java/de/neuland/jade4j/spring/view/JadeView.java
+++ b/src/main/java/de/neuland/jade4j/spring/view/JadeView.java
@@ -4,12 +4,19 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
 import org.springframework.web.servlet.view.AbstractUrlBasedView;
 
 import de.neuland.jade4j.JadeConfiguration;
@@ -31,6 +38,35 @@ public class JadeView extends AbstractUrlBasedView {
 
 		if (contentType != null) {
 			response.setContentType(contentType);
+		}
+
+		/* If we're handling a form with a @ModelAttribute set, we need to unpack BindingResults into a form usable by Jade templates. */
+		for (Map.Entry<String, Object> item : model.entrySet()) {
+
+			if (item.getValue() instanceof BeanPropertyBindingResult) {
+
+				BeanPropertyBindingResult bindingResult = (BeanPropertyBindingResult) item.getValue();
+
+				List<String> globalErrors = new ArrayList<String>();
+
+				for (ObjectError globalError : bindingResult.getGlobalErrors()) {
+					globalErrors.add(globalError.getDefaultMessage());
+				}
+
+				Map<String, String> fieldErrors = new HashMap<String, String>();
+
+				for (FieldError fieldError : bindingResult.getFieldErrors()) {
+					fieldErrors.put(fieldError.getField(), fieldError.getDefaultMessage());
+				}
+
+				/* Always set these values to avoid Jade 'undefined' errors when checking the values in templates. */
+				model.put(bindingResult.getObjectName() + "GlobalErrors", globalErrors);
+				model.put(bindingResult.getObjectName() + "FieldErrors", fieldErrors);
+				model.put(bindingResult.getObjectName() + "HasErrors", !fieldErrors.isEmpty() || !globalErrors.isEmpty());
+
+				/* Remove the unusable BindingResult from the Jade model. */
+				model.remove(BindingResult.MODEL_KEY_PREFIX + bindingResult.getObjectName());
+			}
 		}
 
 		PrintWriter responseWriter = response.getWriter();
@@ -97,10 +133,12 @@ public class JadeView extends AbstractUrlBasedView {
 		this.renderExceptions = renderExceptions;
 	}
 
+	@Override
 	public String getContentType() {
 		return contentType;
 	}
 
+	@Override
 	public void setContentType(String contentType) {
 		this.contentType = contentType;
 	}


### PR DESCRIPTION
When using @ModelAttribute to mark command objects in Spring MVC, Spring injects a BindingResult object with field validation information. Unfortunately we can't access this information from Jade templates because there is no way to call object methods from Jade.

This patch is a quick pass on unpacking any BindingResult instances in the model into multiple variables.

So, for @BindingResult("objectname") the following variables would be set in the Jade model:

objectnameHasErrors, a boolean
objectnameGlobalErrors, a list of global error messages
objectnameFieldErrors, a map of fieldname => error message.

It also removes the unusable BindingResult injected by Spring.

This patch is the minimum needed to do basic form handling with Spring MVC. There are probably a bunch of corner cases that don't work, but it's a start.
