### PR TITLE
Request/Session attribute binding. fixes #9

### DIFF
--- a/src/main/java/de/neuland/jade4j/spring/view/JadeView.java
+++ b/src/main/java/de/neuland/jade4j/spring/view/JadeView.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.web.servlet.view.AbstractTemplateView;
 import org.springframework.web.servlet.view.AbstractUrlBasedView;
 
 import de.neuland.jade4j.JadeConfiguration;
@@ -17,7 +18,7 @@ import de.neuland.jade4j.exceptions.JadeCompilerException;
 import de.neuland.jade4j.exceptions.JadeException;
 import de.neuland.jade4j.template.JadeTemplate;
 
-public class JadeView extends AbstractUrlBasedView {
+public class JadeView extends AbstractTemplateView {
 
 	private String encoding;
 	private JadeConfiguration configuration;
@@ -25,8 +26,11 @@ public class JadeView extends AbstractUrlBasedView {
 	private String contentType;
 
 	@Override
-	protected void renderMergedOutputModel(Map<String, Object> model, HttpServletRequest request, HttpServletResponse response)
-			throws Exception {
+	protected void renderMergedTemplateModel(Map<String, Object> model, HttpServletRequest request, HttpServletResponse response) throws Exception {
+		doRender(model, response);
+	}
+
+	private void doRender(Map<String, Object> model, HttpServletResponse response) throws IOException {
 		logger.trace("Rendering Jade template [" + getUrl() + "] in JadeView '" + getBeanName() + "'");
 
 		if (contentType != null) {

--- a/src/main/java/de/neuland/jade4j/spring/view/JadeViewResolver.java
+++ b/src/main/java/de/neuland/jade4j/spring/view/JadeViewResolver.java
@@ -1,11 +1,12 @@
 package de.neuland.jade4j.spring.view;
 
+import org.springframework.web.servlet.view.AbstractTemplateViewResolver;
 import org.springframework.web.servlet.view.AbstractUrlBasedView;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 
 import de.neuland.jade4j.JadeConfiguration;
 
-public class JadeViewResolver extends UrlBasedViewResolver {
+public class JadeViewResolver extends AbstractTemplateViewResolver {
 
 	private JadeConfiguration configuration;
 	private boolean renderExceptions = false;


### PR DESCRIPTION
Our project uses spring-jade4j.
Spring-jade4j does not regard **HttpServletRequest/HttpSession attributes** as model attributes.
But we have to use a lot of attributes which are injected into request/session from filters and interceptors.

This patch just change the parent classes.
For JadeView, the parent is changed from AbstractUrlBasedView to **AbstractTemplateView**.
For JadeViewResolver, the parent is changed from UrlBasedViewResolver to **AbstractTemplateViewResolver**.

After this patch, org.springframework.web.servlet.support.RequestContext also can be exposed as a model attribute. This can be used for spring theme, locale, messageSource and url handling, etc..
