### PR TITLE
Add SpringHelper with message source access feature.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target/
 .classpath
 .project
 .settings
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -215,5 +215,11 @@
 			<version>4.10</version>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/main/java/de/neuland/jade4j/spring/helper/SpringHelper.java
+++ b/src/main/java/de/neuland/jade4j/spring/helper/SpringHelper.java
@@ -1,0 +1,51 @@
+package de.neuland.jade4j.spring.helper;
+
+import org.springframework.util.Assert;
+import org.springframework.web.servlet.support.RequestContext;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class SpringHelper {
+	public static final String SPRING_HELPER_NAME = "spring";
+
+	private Map<String, Object> model;
+
+	private RequestContext requestContext;
+
+	public SpringHelper(RequestContext requestContext, Map<String, Object> model) {
+		Assert.notNull(requestContext);
+		Assert.notNull(model);
+
+		this.model = model;
+		this.requestContext = requestContext;
+	}
+
+	public Map<String, Object> getModel() {
+		return model;
+	}
+
+	public RequestContext getRequestContext() {
+		return requestContext;
+	}
+
+	public String message(String code) {
+		return requestContext.getMessage(code);
+	}
+
+	public String messageText(String code, String defaultText) {
+		return requestContext.getMessage(code, defaultText);
+	}
+
+	public String messageWithArgs(String code, Object... args) {
+		List<Object> messageArgs = Arrays.asList(args);
+		return requestContext.getMessage(code, messageArgs);
+	}
+
+	public String messageTextWithArgs(String code, String defaultText, Object... args) {
+		List<Object> messageArgs = Arrays.asList(args);
+		return requestContext.getMessage(code, messageArgs, defaultText);
+	}
+
+}

--- a/src/main/java/de/neuland/jade4j/spring/view/JadeViewResolver.java
+++ b/src/main/java/de/neuland/jade4j/spring/view/JadeViewResolver.java
@@ -1,10 +1,8 @@
 package de.neuland.jade4j.spring.view;
 
+import de.neuland.jade4j.JadeConfiguration;
 import org.springframework.web.servlet.view.AbstractTemplateViewResolver;
 import org.springframework.web.servlet.view.AbstractUrlBasedView;
-import org.springframework.web.servlet.view.UrlBasedViewResolver;
-
-import de.neuland.jade4j.JadeConfiguration;
 
 public class JadeViewResolver extends AbstractTemplateViewResolver {
 

--- a/src/test/java/de/neuland/jade4j/spring/helper/SpringHelperTest.java
+++ b/src/test/java/de/neuland/jade4j/spring/helper/SpringHelperTest.java
@@ -1,0 +1,204 @@
+package de.neuland.jade4j.spring.helper;
+
+import de.neuland.jade4j.JadeConfiguration;
+import de.neuland.jade4j.template.JadeTemplate;
+import de.neuland.jade4j.template.TemplateLoader;
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+import org.springframework.web.servlet.support.RequestContext;
+import org.springframework.web.servlet.view.AbstractTemplateView;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SpringHelperTest {
+
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+
+	@Mock
+	private RequestContext requestContext;
+
+	@Mock
+	private TemplateLoader templateLoader;
+
+	private Map<String, Object> model;
+
+	JadeConfiguration jadeConfig;
+
+	private SpringHelper springHelper;
+
+	@Before
+	public void setUp() throws IOException {
+		model = new HashMap<String, Object>();
+		model.put(AbstractTemplateView.SPRING_MACRO_REQUEST_CONTEXT_ATTRIBUTE, requestContext);
+
+		springHelper = new SpringHelper(requestContext, model);
+
+		Map<String, Object> sharedVariables = new HashMap<String, Object>();
+		sharedVariables.put(SpringHelper.SPRING_HELPER_NAME, springHelper);
+
+		jadeConfig = new JadeConfiguration();
+		jadeConfig.setSharedVariables(sharedVariables);
+		jadeConfig.setCaching(false);
+
+		setUpStringTemplateLoader();
+
+		jadeConfig.setTemplateLoader(templateLoader);
+	}
+
+	private void setUpStringTemplateLoader() throws IOException {
+		when(templateLoader.getLastModified(any(String.class))).thenReturn(-1L);
+		when(templateLoader.getReader(any(String.class))).thenAnswer(new Answer<Reader>() {
+
+			@Override
+			public Reader answer(InvocationOnMock invocation) throws Throwable {
+				String name = (String) invocation.getArguments()[0];
+				return new StringReader(name);
+			}
+		});
+	}
+
+	@Test
+	public void constructor_no_requestContext() {
+		exception.expect(IllegalArgumentException.class);
+
+		new SpringHelper(null, new HashMap<String, Object>());
+	}
+
+	@Test
+	public void constructure_no_model() {
+		exception.expect(IllegalArgumentException.class);
+
+		new SpringHelper(requestContext, null);
+	}
+
+	@Test
+	public void constructor_with_requestContext() {
+		assertThat(springHelper.getRequestContext(), sameInstance(requestContext));
+	}
+
+	private String r(String template) {
+		try {
+			JadeTemplate jadeTemplate = jadeConfig.getTemplate(template);
+			return jadeConfig.renderTemplate(jadeTemplate, model);
+		} catch (IOException e) {
+			throw new IllegalStateException(e.getMessage(), e);
+		}
+	}
+
+	@Test
+	public void message_normal_text() {
+		String code = "test.code";
+		String message = "Test normal message";
+
+		when(requestContext.getMessage(code)).thenReturn(message);
+		assertThat(r("p= spring.message('test.code')"), is("<p>" + message + "</p>"));
+	}
+
+	@Test
+	public void message_escape() {
+		String code = "test.code";
+		String message = "Test >.< escape message";
+
+		when(requestContext.getMessage(code)).thenReturn(message);
+		assertThat(r("p= spring.message('test.code')"), is("<p>" + StringEscapeUtils.escapeHtml4(message) + "</p>"));
+	}
+
+	@Test
+	public void message_not_escape() {
+		String code = "test.code";
+		String message = "Test >.< not escape Message";
+
+		when(requestContext.getMessage(code)).thenReturn(message);
+		assertThat(r("p!= spring.message('test.code')"), is("<p>" + message + "</p>"));
+	}
+
+	@Test
+	public void message_middle_of_text_escape() {
+		String code = "test.code";
+		String message = "Jade >.< Escape";
+
+		when(requestContext.getMessage(code)).thenReturn(message);
+		assertThat(r("p Hello, #{spring.message('test.code')}!"), is("<p>Hello, " + StringEscapeUtils.escapeHtml4(message) + "!</p>"));
+	}
+
+	@Test
+	public void message_middle_of_text_not_escape() {
+		String code = "test.code";
+		String message = "Jade >.< not escape ";
+
+		when(requestContext.getMessage(code)).thenReturn(message);
+		assertThat(r("p Hello, !{spring.message('test.code')}!"), is("<p>Hello, " + message + "!</p>"));
+	}
+
+	@Test
+	public void messageText() {
+		String code = "test.default";
+		String defaultMessage = "Hello MessageText";
+
+		when(requestContext.getMessage(code, defaultMessage)).thenReturn(defaultMessage);
+		assertThat(r("p= spring.messageText('test.default', '" + defaultMessage + "')"), is("<p>" + defaultMessage + "</p>"));
+	}
+
+	@Test
+	public void messageTextWithArgs() {
+		String code = "test.text.varargs";
+		String defaultMessage = "Hell Message Text With Args";
+
+		Double arg1 = 100.11;
+		String arg2 = "Arg2";
+		String arg3 = "Arg3";
+
+		List<Object> args = new ArrayList<Object>();
+		args.add(arg1);
+		args.add(arg2);
+		args.add(arg3);
+
+		model.put("defaultMessage", defaultMessage);
+		model.put("arg1", arg1);
+		model.put("arg2", arg2);
+		model.put("arg3", arg3);
+
+		when(requestContext.getMessage(code, args, defaultMessage)).thenReturn(defaultMessage);
+		assertThat(r("p= spring.messageTextWithArgs('test.text.varargs', defaultMessage, arg1, arg2, arg3)"), is("<p>" + defaultMessage + "</p>"));
+	}
+
+	@Test
+	public void messageWithArgs() {
+		String code = "test.varargs";
+		String message = "Hello Message With Args";
+		Integer arg1 = 1;
+		String arg2 = "arg2";
+
+		List<Object> args = new ArrayList<Object>();
+		args.add(arg1);
+		args.add(arg2);
+
+		model.put("arg1", arg1);
+		model.put("arg2", arg2);
+
+		when(requestContext.getMessage(code, args)).thenReturn(message);
+		assertThat(r("p= spring.messageWithArgs('test.varargs', arg1, arg2)"), is("<p>" + message + "</p>"));
+	}
+}

--- a/src/test/java/de/neuland/jade4j/spring/view/JadeViewTest.java
+++ b/src/test/java/de/neuland/jade4j/spring/view/JadeViewTest.java
@@ -1,0 +1,60 @@
+package de.neuland.jade4j.spring.view;
+
+import de.neuland.jade4j.JadeConfiguration;
+import de.neuland.jade4j.spring.helper.SpringHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.web.servlet.support.RequestContext;
+import org.springframework.web.servlet.view.AbstractTemplateView;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JadeViewTest {
+
+	private JadeView jadeView;
+
+	@Mock
+	private JadeConfiguration configuration;
+
+	@Mock
+	private HttpServletRequest request;
+
+	@Mock
+	private RequestContext requestContext;
+
+	@Before
+	public void setUp() {
+		jadeView = new JadeView();
+	}
+
+	@Test
+	public void exposeHelpers_expose() throws Exception {
+		Map<String, Object> model = new HashMap<String, Object>();
+		model.put(AbstractTemplateView.SPRING_MACRO_REQUEST_CONTEXT_ATTRIBUTE, requestContext);
+
+		jadeView.exposeHelpers(model, request);
+
+		SpringHelper springHelper = (SpringHelper) model.get(SpringHelper.SPRING_HELPER_NAME);
+		assertThat(springHelper, not(nullValue()));
+		assertThat(springHelper.getRequestContext(), is(requestContext));
+	}
+
+	@Test
+	public void exposeHelpers_not_expose() throws Exception {
+		Map<String, Object> model = new HashMap<String, Object>();
+
+		jadeView.exposeHelpers(model, request);
+
+		SpringHelper springHelper = (SpringHelper) model.get(SpringHelper.SPRING_HELPER_NAME);
+		assertThat(springHelper, nullValue());
+	}
+}


### PR DESCRIPTION
I made `SpringHelper` for spring-jade4j.
This version only has **message(Message Source)** related methods. I'm going to add bind and form related methods soon.

If you set `viewResolver.setExposeSpringMacroHelpers(true)`, `SpringHelper` will be injected to model object automatically as 'spring'. And when you have `messageSource` bean, you can use `SpringHelper` like the following.

```
p Message from message source : #{spring.message('test.message')}!
p= spring.messageWithArgs('test.format', 'format argment 1', formatArgumentFromModel)
p Default Text test #{spring.messageText('unknown.code', 'Default text can be here.')}
```

```
JadeViewResolver viewResolver = new JadeViewResolver();
viewResolver.setExposeSpringMacroHelpers(true);

viewResolver.setExposeRequestAttributes(true);
viewResolver.setExposeSessionAttributes(true);
//...
```
